### PR TITLE
Allow >2MB search index to be cached

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,7 +49,10 @@ export default defineConfig({
         swDest: "dist/sw.js",
         globDirectory: "dist",
         globPatterns: ["**/*.{html,js,css,json,png,ico,svg,woff,woff2}"],
-        globIgnores: ["sw.dev.js"],
+        globIgnores: [
+          "sw.dev.js",
+          "search-index.json", // Too large for precache — runtime cached via StaleWhileRevalidate in sw.js
+        ],
       },
       injectRegister: false,
       manifest: false,

--- a/public/sw.js
+++ b/public/sw.js
@@ -84,13 +84,13 @@ workbox.routing.registerRoute(
     ],
   }),
 );
-    ],
+],
   }),
-);
+)
 
 // This is your Service Worker, you can put any of your custom Service Worker
 // code in this file, above the `precacheAndRoute` line.
 
 // All HTML pages are included in __WB_MANIFEST via globPatterns.
 // precacheAndRoute handles navigation requests automatically (including /path → /path/index.html).
-workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || [])

--- a/public/sw.js
+++ b/public/sw.js
@@ -65,6 +65,20 @@ workbox.routing.registerRoute(
   }),
 );
 
+// search-index.json is too large for precaching and not needed on initial load.
+// Cache on first search use, serve from cache while revalidating in the background.
+workbox.routing.registerRoute(
+  ({ url }) => url.pathname.endsWith("/search-index.json"),
+  new workbox.strategies.StaleWhileRevalidate({
+    cacheName: "search-index",
+    plugins: [
+      new workbox.cacheableResponse.CacheableResponsePlugin({
+        statuses: [0, 200],
+      }),
+    ],
+  }),
+);
+
 // This is your Service Worker, you can put any of your custom Service Worker
 // code in this file, above the `precacheAndRoute` line.
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -90,4 +90,4 @@ workbox.routing.registerRoute(
 
 // All HTML pages are included in __WB_MANIFEST via globPatterns.
 // precacheAndRoute handles navigation requests automatically (including /path → /path/index.html).
-workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || [])
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST || []);

--- a/public/sw.js
+++ b/public/sw.js
@@ -84,9 +84,6 @@ workbox.routing.registerRoute(
     ],
   }),
 );
-],
-  }),
-)
 
 // This is your Service Worker, you can put any of your custom Service Worker
 // code in this file, above the `precacheAndRoute` line.

--- a/public/sw.js
+++ b/public/sw.js
@@ -68,13 +68,22 @@ workbox.routing.registerRoute(
 // search-index.json is too large for precaching and not needed on initial load.
 // Cache on first search use, serve from cache while revalidating in the background.
 workbox.routing.registerRoute(
-  ({ url }) => url.pathname.endsWith("/search-index.json"),
+  ({ url, request }) =>
+    request.method === "GET" &&
+    url.origin === self.location.origin &&
+    url.pathname.endsWith("/search-index.json"),
   new workbox.strategies.StaleWhileRevalidate({
     cacheName: "search-index",
     plugins: [
       new workbox.cacheableResponse.CacheableResponsePlugin({
-        statuses: [0, 200],
+        statuses: [200],
       }),
+      new workbox.expiration.ExpirationPlugin({
+        maxEntries: 1,
+      }),
+    ],
+  }),
+);
     ],
   }),
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Search index is excluded from precaching and is now fetched/cached at runtime.
  * Runtime caching uses a stale-while-revalidate strategy with a single-entry cache and only stores successful responses, improving initial load, keeping results fresh in the background, and increasing reliability for search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->