### PR TITLE
test: add per-engine visual baselines for component gallery

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -1,0 +1,41 @@
+name: Visual Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  visual:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.23"
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium webkit
+
+      # Behavioural specs gate the run (engine-level, OS-independent); the gallery
+      # spec captures a full-page screenshot per engine into the HTML report.
+      - name: Run visual tests
+        run: bun run test:visual
+
+      # Expiring artifact — the screenshots to eyeball; uploaded even on failure.
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Playwright (baselines under tests/**/*-snapshots are committed; these are not)
+/test-results/
+/playwright-report/
+/playwright/.cache/
+
 # temporary dev service worker
 /public/sw.dev.js
 /public/search-index.json

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -41,7 +41,26 @@ export default defineConfig({
   base: process.env.ASTRO_BASE || undefined,
   output: "static",
   integrations: [
-    sitemap(),
+    // Gallery route lives in tests/visual/ and is injected only when Playwright asks for it,
+    // so normal `bun run build` never emits it.
+    ...(process.env.INCLUDE_GALLERY === "1"
+      ? [
+          {
+            name: "inject-gallery",
+            hooks: {
+              "astro:config:setup": ({ injectRoute }) => {
+                injectRoute({
+                  pattern: "/component-gallery",
+                  entrypoint: "./tests/visual/component-gallery.astro",
+                });
+              },
+            },
+          },
+        ]
+      : []),
+    sitemap({
+      filter: (page) => !page.includes("/component-gallery"),
+    }),
     AstroPWA({
       strategies: "injectManifest",
       injectManifest: {

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
+        "@playwright/test": "^1.61.0",
         "@types/node": "^24.3.0",
         "@vite-pwa/assets-generator": "^1.0.1",
         "@vite-pwa/astro": "^1.2.0",
@@ -387,6 +388,8 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
+    "@playwright/test": ["@playwright/test@1.61.0", "", { "dependencies": { "playwright": "1.61.0" }, "bin": { "playwright": "cli.js" } }, "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA=="],
+
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
@@ -735,7 +738,7 @@
 
     "fs-extra": ["fs-extra@9.1.0", "", { "dependencies": { "at-least-node": "^1.0.0", "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1084,6 +1087,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
+
+    "playwright-core": ["playwright-core@1.61.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1483,6 +1490,8 @@
 
     "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -1494,6 +1503,8 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "terser/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "vite/rollup": ["rollup@4.54.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.54.0", "@rollup/rollup-android-arm64": "4.54.0", "@rollup/rollup-darwin-arm64": "4.54.0", "@rollup/rollup-darwin-x64": "4.54.0", "@rollup/rollup-freebsd-arm64": "4.54.0", "@rollup/rollup-freebsd-x64": "4.54.0", "@rollup/rollup-linux-arm-gnueabihf": "4.54.0", "@rollup/rollup-linux-arm-musleabihf": "4.54.0", "@rollup/rollup-linux-arm64-gnu": "4.54.0", "@rollup/rollup-linux-arm64-musl": "4.54.0", "@rollup/rollup-linux-loong64-gnu": "4.54.0", "@rollup/rollup-linux-ppc64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-gnu": "4.54.0", "@rollup/rollup-linux-riscv64-musl": "4.54.0", "@rollup/rollup-linux-s390x-gnu": "4.54.0", "@rollup/rollup-linux-x64-gnu": "4.54.0", "@rollup/rollup-linux-x64-musl": "4.54.0", "@rollup/rollup-openharmony-arm64": "4.54.0", "@rollup/rollup-win32-arm64-msvc": "4.54.0", "@rollup/rollup-win32-ia32-msvc": "4.54.0", "@rollup/rollup-win32-x64-gnu": "4.54.0", "@rollup/rollup-win32-x64-msvc": "4.54.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw=="],
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "biome check",
     "format": "biome check --write",
     "generate-pwa-assets": "pwa-assets-generator",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test:visual": "playwright test",
+    "test:visual:report": "playwright show-report"
   },
   "author": "",
   "license": "ISC",
@@ -33,6 +35,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
+    "@playwright/test": "^1.61.0",
     "@types/node": "^24.3.0",
     "@vite-pwa/assets-generator": "^1.0.1",
     "@vite-pwa/astro": "^1.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Per-engine visual regression. Cross-engine pixel diffing is intentionally not done
+// (antialiasing/fonts always differ); engines are compared by eye via their baselines.
+export default defineConfig({
+  testDir: "./tests/visual",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:4321",
+    colorScheme: "light",
+    reducedMotion: "reduce",
+  },
+  projects: [
+    { name: "webkit", use: { ...devices["iPhone 13"] } },
+    { name: "chromium", use: { ...devices["Pixel 5"] } },
+  ],
+  webServer: {
+    command: "bun run build && bun run preview",
+    url: "http://localhost:4321",
+    env: { INCLUDE_GALLERY: "1" },
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/src/components/sticky-button.ts
+++ b/src/components/sticky-button.ts
@@ -64,6 +64,10 @@ export class StickyButton extends LitElement {
       padding: 0.3rem 1ch;
       font-size: 0.9rem;
       cursor: pointer;
+      /* WebKit gives native <button> text a system color (blue on iOS) instead of inheriting;
+         force inherit so the number matches the page color on every engine. */
+      color: inherit;
+      -webkit-text-fill-color: currentColor;
     }
 
     .sticky.verse {

--- a/tests/visual/component-gallery.astro
+++ b/tests/visual/component-gallery.astro
@@ -1,0 +1,102 @@
+---
+import ContentRenderer from "@/components/astro/ContentRenderer.astro";
+import BaseLayout from "@/layouts/BaseLayout.astro";
+import { NavModel } from "@/models/nav";
+import {
+  DhikrEntryModel,
+  DhikrModel,
+  ExpandModel,
+  QasidaChapterModel,
+  QasidaEntryModel,
+  QasidaModel,
+  QasidaVerseModel,
+  QuranDhikrEntryModel,
+  QuranEntryModel,
+  QuranModel,
+  WirdModel,
+} from "@/models/recitation";
+
+const PAGE_PATH = "/component-gallery";
+const sampleAudio = { url: "/sample-audio", title: "Sample audio" };
+
+const quran = new QuranModel({
+  title: "Al-Ikhlas",
+  surah: 112,
+  basmallah: true,
+  entries: [
+    new QuranEntryModel({ arabic: "قُلْ هُوَ ٱللَّهُ أَحَدٌ", translit: "Qul huwa Allahu ahad", translation: "Say, He is Allah, One", verse: 1 }),
+    new QuranEntryModel({ arabic: "ٱللَّهُ ٱلصَّمَدُ", translit: "Allahu as-samad", translation: "Allah, the Eternal Refuge", verse: 2 }),
+  ],
+});
+
+const dhikr = new DhikrModel({
+  title: "Tasbih",
+  instruction: "Recite after the prayer",
+  repeat: 100,
+  entries: [
+    new DhikrEntryModel({ arabic: "سُبْحَانَ ٱللَّٰهِ", translit: "Subhan Allah", translation: "Glory be to Allah", repeat: 33, enableCounter: true }),
+    new QuranDhikrEntryModel({ arabic: "ءَامَنَ ٱلرَّسُولُ", translit: "Amana ar-rasul", translation: "The Messenger has believed", verse: 285, surah: 2 }),
+  ],
+});
+
+const expand = new ExpandModel({
+  title: "Optional section",
+  startExpanded: true,
+  entries: [
+    new DhikrModel({ entries: [new DhikrEntryModel({ arabic: "ٱلْحَمْدُ لِلَّٰهِ", translit: "Alhamdulillah", translation: "Praise be to Allah" })] }),
+  ],
+});
+
+const wird = new WirdModel({
+  title: "Morning Wird",
+  audio: sampleAudio,
+  entries: [
+    new DhikrModel({ title: "Opening", entries: [new DhikrEntryModel({ arabic: "بِسْمِ ٱللَّٰهِ", translit: "Bismillah", translation: "In the name of Allah" })] }),
+    new QuranModel({ title: "Al-Fatihah", surah: 1, entries: [new QuranEntryModel({ arabic: "ٱلْحَمْدُ لِلَّٰهِ رَبِّ ٱلْعَٰلَمِينَ", translit: "Alhamdu lillahi rabbil alamin", translation: "Praise be to Allah, Lord of the worlds", verse: 2 })] }),
+    new ExpandModel({ title: "Closing dua", entries: [new DhikrModel({ entries: [new DhikrEntryModel({ arabic: "آمِين", translit: "Amin", translation: "Amen" })] })] }),
+  ],
+});
+
+const qasida = new QasidaModel({
+  title: "Sample Qasida",
+  audio: sampleAudio,
+  entries: [
+    new QasidaChapterModel({
+      number: 1,
+      title: "Chapter One",
+      entries: [
+        new QasidaVerseModel({ entries: [new QasidaEntryModel({ arabic: "يَا نَبِيَّ سَلَامٌ عَلَيْكَ", translit: "Ya nabi salam alayka", translation: "O Prophet, peace be upon you" })] }),
+        new QasidaVerseModel({ chorus: true, entries: [new QasidaEntryModel({ arabic: "صَلَوَاتُ ٱللَّٰهِ عَلَيْكَ", translit: "Salawatu llahi alayka", translation: "The blessings of Allah upon you" })] }),
+      ],
+    }),
+  ],
+});
+
+const nav = [
+  new NavModel({ href: "component-gallery", title: "Sample Link A" }),
+  new NavModel({ href: "component-gallery", title: "Sample Link B" }),
+];
+
+const sections = [
+  { id: "quran", items: [quran] },
+  { id: "dhikr", items: [dhikr] },
+  { id: "wird", items: [wird] },
+  { id: "qasida", items: [qasida] },
+  { id: "expand", items: [expand] },
+  { id: "nav", items: nav },
+];
+---
+
+<BaseLayout title="Component Gallery" pagePath={PAGE_PATH}>
+  {sections.map((s) => (
+    <section data-testid={s.id} style="margin-block:2rem;">
+      <ContentRenderer items={s.items} pagePath={PAGE_PATH} />
+    </section>
+  ))}
+
+  <section data-testid="sticky-buttons" style="display:flex; gap:1rem; margin-block:2rem;">
+    <kp-sticky-button label="1" elementId="sb-entry" variant="entry"></kp-sticky-button>
+    <kp-sticky-button label="2" elementId="sb-verse" variant="verse"></kp-sticky-button>
+    <kp-sticky-button label="3" elementId="sb-chapter" variant="chapter"></kp-sticky-button>
+  </section>
+</BaseLayout>

--- a/tests/visual/gallery.spec.ts
+++ b/tests/visual/gallery.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "@playwright/test";
+
+// One spec for the gallery, run per engine:
+//   1. capture a full-page screenshot into the report (expiring CI artifact —
+//      no committed baseline, no pixel diff), and
+//   2. assert the behavioural regression gate: every kp-sticky-button's text
+//      inherits the page colour. WebKit otherwise defaults native <button> text
+//      to a system colour (blue on iOS), so this catches the bug on every engine.
+test("component gallery: capture full-page screenshot + sticky-button colour invariant", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/component-gallery");
+  await page.evaluate(() => document.fonts.ready);
+  await page.waitForLoadState("networkidle"); // Shoelace icons load from CDN
+  await page.waitForFunction(() => {
+    const els = [...document.querySelectorAll("kp-sticky-button")];
+    return (
+      els.length > 0 && els.every((e) => e.shadowRoot?.querySelector("button.sticky"))
+    );
+  });
+
+  // Capture first so the artifact exists even if the assertions below fail.
+  const image = await page.screenshot({ fullPage: true });
+  await testInfo.attach(`gallery-${testInfo.project.name}`, {
+    body: image,
+    contentType: "image/png",
+  });
+
+  // Gate: every sticky-button variant inherits the page colour, not the engine's
+  // native-button default.
+  const results = await page.evaluate(() => {
+    const hosts = [...document.querySelectorAll("kp-sticky-button")];
+    return hosts.map((host) => ({
+      variant: host.getAttribute("variant"),
+      buttonColor: getComputedStyle(
+        host.shadowRoot!.querySelector("button.sticky")!,
+      ).color,
+      pageColor: getComputedStyle(host).color,
+    }));
+  });
+  expect(results.length).toBeGreaterThan(0);
+  for (const { variant, buttonColor, pageColor } of results) {
+    expect(buttonColor, `variant ${variant}`).toBe(pageColor);
+  }
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebKit text color rendering for sticky buttons so the button label color matches the page styling consistently.

* **New Features**
  * Added a “Component Gallery” page (used by visual tests) and excluded it from the sitemap.

* **Tests**
  * Introduced Playwright visual regression testing with cross-engine projects, a dedicated full-page screenshot check, and a CI-ready test flow (including new npm scripts).

* **Chores**
  * Updated ignore rules for Playwright runtime artifacts and temporary dev assets.

* **CI**
  * Added an automated GitHub Actions workflow to run the visual test suite on push and pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->